### PR TITLE
Add Spark Mail

### DIFF
--- a/lib/apps/spark-mail.ts
+++ b/lib/apps/spark-mail.ts
@@ -1,0 +1,23 @@
+import { findPattern } from "@/lib/findPattern";
+import { FixedStatus, type AppMeta } from "../../types";
+
+export const SparkMail: AppMeta = {
+  icon: "https://static.helpjuice.com/helpjuice_production/uploads/upload/image/11007/direct/spark-icon-96x96.png",
+  id: "spark-mail-stable",
+  friendlyName: "Spark Mail",
+  twitter: "SparkMailApp",
+  async checkIsFixed() {
+    const url = await fetch(
+      "https://downloads.sparkmailapp.com/Spark3/mac/dist/appcast.xml"
+    )
+      .then((res) => res.text())
+      .then(
+        // Match with RegEx to avoid bringing a whole XML parser dependency just for this
+        (text) => text?.match(/<enclosure\s+url="([^"]+\.dmg)"/)?.[1]
+      );
+
+    const pat = "_cornerMask";
+    const result = await findPattern(url!, pat, {useGetCheck: true});
+    return result?.found ? FixedStatus.NOT_FIXED : FixedStatus.FIXED;
+  },
+};


### PR DESCRIPTION
I had to add an option in `findPattern()` to do a `GET` request instead of a `HEAD` request because the Google Cloud Storage bucket of Spark Mail has the `HEAD` method disabled entirely.

Running this:

```sh
curl -I "https://downloads.sparkmailapp.com/Spark3/mac/dist/3.26.0.117233/Spark.dmg"
```

Returns a `HTTP/2 405` which means `Method Not Allowed`.
