### PR TITLE
Add Keybase

### DIFF
--- a/lib/apps/keybase.ts
+++ b/lib/apps/keybase.ts
@@ -8,18 +8,7 @@ export const Keybase: AppMeta = {
   friendlyName: "Keybase",
   twitter: "keybaseio",
   async checkIsFixed() {
-    const url = await fetch(
-      "https://api.github.com/repos/keybase/client/releases/latest"
-    )
-      .then((res) => res.json())
-      .then(
-        (data) =>
-          data.assets.find(
-            (asset: { name: string }) =>
-              asset.name.startsWith("keybase-v") &&
-              asset.name.endsWith(".tar.xz")
-          )?.browser_download_url
-      );
+    const url = "https://prerelease.keybase.io/Keybase-arm64.dmg";
     const pat = "_cornerMask";
     const result = await findPattern(url, pat);
     return result?.found ? FixedStatus.NOT_FIXED : FixedStatus.FIXED;


### PR DESCRIPTION
Add Keybase. Keybase 6.5.4 is the latest version and is using Electron 28.3.1. The Keybase client releases page is outdated by 3 versions (6.5.1) but nonetheless appears to be the only place changelogs are posted or easily accessible.