### PR TITLE
Add AnythingLLM, SideQuest, and Upscayl apps

### DIFF
--- a/lib/apps/anythingllm.ts
+++ b/lib/apps/anythingllm.ts
@@ -1,0 +1,24 @@
+import { findPattern } from "@/lib/findPattern";
+import { FixedStatus, type AppMeta } from "../../types";
+
+export const AnythingLLM: AppMeta = {
+  icon: "https://raw.githubusercontent.com/Mintplex-Labs/anything-llm/master/images/icon.png",
+  id: "anythingllm-stable",
+  friendlyName: "AnythingLLM",
+  twitter: "anythingLLMapp",
+  async checkIsFixed() {
+    const url = await fetch(
+      "https://api.github.com/repos/Mintplex-Labs/anything-llm/releases/latest"
+    )
+      .then((res) => res.json())
+      .then(
+        (data) =>
+          data.assets.find((asset: { name: string }) =>
+            asset.name.includes("mac-")
+          )?.browser_download_url
+      );
+    const pat = "_cornerMask";
+    const result = await findPattern(url, pat);
+    return result?.found ? FixedStatus.NOT_FIXED : FixedStatus.FIXED;
+  },
+};

--- a/lib/apps/sidequest.ts
+++ b/lib/apps/sidequest.ts
@@ -1,0 +1,24 @@
+import { findPattern } from "@/lib/findPattern";
+import { FixedStatus, type AppMeta } from "../../types";
+
+export const SideQuest: AppMeta = {
+  icon: "https://cdn.sidequestvr.com/images/logo.png",
+  id: "sidequest-stable",
+  friendlyName: "SideQuest",
+  twitter: "SideQuestVR",
+  async checkIsFixed() {
+    const url = await fetch(
+      "https://api.github.com/repos/SideQuestVR/SideQuest/releases/latest"
+    )
+      .then((res) => res.json())
+      .then(
+        (data) =>
+          data.assets.find((asset: { name: string }) =>
+            asset.name.endsWith(".dmg")
+          )?.browser_download_url
+      );
+    const pat = "_cornerMask";
+    const result = await findPattern(url, pat);
+    return result?.found ? FixedStatus.NOT_FIXED : FixedStatus.FIXED;
+  },
+};

--- a/lib/apps/upscayl.ts
+++ b/lib/apps/upscayl.ts
@@ -1,0 +1,24 @@
+import { findPattern } from "@/lib/findPattern";
+import { FixedStatus, type AppMeta } from "../../types";
+
+export const Upscayl: AppMeta = {
+  icon: "https://raw.githubusercontent.com/upscayl/upscayl/main/resources/icon.png",
+  id: "upscayl-stable",
+  friendlyName: "Upscayl",
+  twitter: "upscayl",
+  async checkIsFixed() {
+    const url = await fetch(
+      "https://api.github.com/repos/upscayl/upscayl/releases/latest"
+    )
+      .then((res) => res.json())
+      .then(
+        (data) =>
+          data.assets.find((asset: { name: string }) =>
+            asset.name.endsWith("-mac.dmg")
+          )?.browser_download_url
+      );
+    const pat = "_cornerMask";
+    const result = await findPattern(url, pat);
+    return result?.found ? FixedStatus.NOT_FIXED : FixedStatus.FIXED;
+  },
+};


### PR DESCRIPTION
## Summary
- Add AnythingLLM: AI/LLM application affected by _cornerMask issue
- Add SideQuest: VR sideloading tool affected by _cornerMask issue
- Add Upscayl: Image upscaler affected by _cornerMask issue

These apps were detected as having both outdated Electron versions and the _cornerMask symbol, making them affected by the macOS WindowServer performance issue.

All three apps follow the existing pattern and use `findPattern` to check for the `_cornerMask` symbol in their latest release binaries.

## Test plan
- [x] Verified TypeScript compilation succeeds
- [x] Confirmed apps are properly exported in generated index.ts
- [x] Validated app metadata follows existing conventions
- [x] Tested Next.js build process (compilation successful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)